### PR TITLE
Revert "Bump actions/setup-node from v1 to v2.1.4"

### DIFF
--- a/.github/workflows/Code Check.yml
+++ b/.github/workflows/Code Check.yml
@@ -23,7 +23,7 @@ jobs:
           # The arguments to pass to HTMLProofer
             
     - name: Get Node.js
-      uses: actions/setup-node@v2.1.4
+      uses: actions/setup-node@v1
       with:
           node-version: "12.x"
 


### PR DESCRIPTION
Reverts BC-Youth-Council/donate#1

This seems to break the npm ci step